### PR TITLE
Fix uploads routing

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -805,7 +805,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     "/uploads",
     (req, res, next) => {
       // Basic security check
-      const filePath = path.join(uploadDir, req.path);
+      const filePath = path.resolve(uploadDir, "." + req.path);
       if (!filePath.startsWith(uploadDir)) {
         return res.status(403).json({ message: "Access denied" });
       }

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,10 @@
       "destination": "/api/server"
     },
     {
+      "source": "/uploads/(.*)",
+      "destination": "/api/server/uploads/$1"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary
- ensure the uploads middleware resolves file paths relative to the upload directory before performing the security check
- add a Vercel rewrite so /uploads/* requests are forwarded to the Express server instead of the SPA fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4e25a85dc8321be5b2abe916a7f06